### PR TITLE
CI(Release): Build image on push to main branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [ main ]
     tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ main ]
 
 env:
   REGISTRY: registry.dev.rafay-edge.net
@@ -34,7 +36,6 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=schedule
             type=ref,event=branch
             type=ref,event=tag
             type=ref,event=pr


### PR DESCRIPTION
Run release CI pipeline on main branch push event. The following docker tags are created on a push event:

```
Docker tags
  registry.dev.rafay-edge.net/rafaylabs/rcloud-console-ui:main
  registry.dev.rafay-edge.net/rafaylabs/rcloud-console-ui:sha-c1bd35b
  registry.dev.rafay-edge.net/rafaylabs/rcloud-console-ui:pr-67
```

ref: https://github.com/RafayLabs/rcloud-base/issues/144