### PR TITLE
removing building images to registry on pull requests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [ main ]
     tags: [ 'v*.*.*' ]
-  pull_request:
-    branches: [ main ]
 
 env:
   REGISTRY: docker.io

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 ### Changed
 - Hide copy button on non https webpages from [meain](https://github.com/meain)
+- Removed building images to registry on pull requests [niravparikh05](https://github.com/niravparikh05)
 ### Fixed
 - Fix blank screen on initial login from [meain](https://github.com/meain)
 


### PR DESCRIPTION
### What does this PR change?

- Removes gh action to build images on pull requests

### Does the PR depend on any other PRs or Issues? If yes, please list them.

- No

### Checklist

I confirm, that I have...

- [x] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Added tests for this PR
- [ ] Formatted the code using `npm run format` (if applicable)
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [x] Updated `CHANGELOG.md`
