### PR TITLE
Fix timestamp rendering for audit logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Removed building images to registry on pull requests [niravparikh05](https://github.com/niravparikh05)
 ### Fixed
 - Fix blank screen on initial login from [meain](https://github.com/meain)
+- Fix time/date rendering in audit logs from [meain](https://github.com/meain)
 
 ## [0.1.0] - 2022-06-22
 ### Added

--- a/src/appMain/routes/auditLogs/KubectlLogs/RelayAPI/components/AuditLogsTable.js
+++ b/src/appMain/routes/auditLogs/KubectlLogs/RelayAPI/components/AuditLogsTable.js
@@ -19,7 +19,7 @@ const AuditLogsTable = (props) => {
   const parseRowData = (data, index) => [
     {
       type: "regular",
-      value: <DateFormat date={data._source.json.ts} />,
+      value: <DateFormat timestamp={data._source.json.ts} />,
       stringValue: data._source.json.ts,
     },
     {

--- a/src/appMain/routes/auditLogs/components/LogsDataTable/index.js
+++ b/src/appMain/routes/auditLogs/components/LogsDataTable/index.js
@@ -51,7 +51,7 @@ const LogsDataTable = (props) => {
     [
       {
         type: "regular",
-        value: <DateFormat date={data._source.json.timestamp} />,
+        value: <DateFormat timestamp={data._source.json.timestamp} />,
         stringValue: data._source.json.timestamp,
       },
       {

--- a/src/components/DateFormat.js
+++ b/src/components/DateFormat.js
@@ -11,9 +11,19 @@ const dateFormatOptions = {
 const DateFormat = ({ timestamp }) => {
   if (!timestamp) return "-";
   try {
-    return new Intl.DateTimeFormat("en-US", dateFormatOptions).format(
-      new Date(timestamp.seconds * 1000 + timestamp.nanos / 1e6)
-    );
+    if (typeof timestamp === "number") {
+      return new Intl.DateTimeFormat("en-US", dateFormatOptions).format(
+        timestamp
+      );
+    } else if (typeof timestamp === "string") {
+      return new Intl.DateTimeFormat("en-US", dateFormatOptions).format(
+        Date.parse(timestamp)
+      );
+    } else {
+      return new Intl.DateTimeFormat("en-US", dateFormatOptions).format(
+        new Date(timestamp.seconds * 1000 + timestamp.nanos / 1e6)
+      );
+    }
   } catch (error) {
     return "-";
   }


### PR DESCRIPTION
### What does this PR change?

Timestamps in audit logs where not being rendered properly and this fixes it.
![image](https://user-images.githubusercontent.com/14259816/181490144-0919d734-809b-407d-937f-579dd09e7c2d.png)

### Checklist

I confirm, that I have...

- [x] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Added tests for this PR
- [x] Formatted the code using `npm run format` (if applicable)
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [x] Updated `CHANGELOG.md`
