### PR TITLE
Fix kubeconfig download file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Fix download kubeconfig file name issue from [akshay196](https://github.com/akshay196)
 
 ### Fixed
 - Ui cleanups in cluster lister, import and config screens from [niravparikh05](https://github.com/niravparikh05)

--- a/src/appMain/routes/tools/details/components/DownloadKubeconfig.js
+++ b/src/appMain/routes/tools/details/components/DownloadKubeconfig.js
@@ -16,7 +16,7 @@ const DownloadKubeconfig = ({ user, withIcon }) => {
   useEffect(() => {
     if (config) {
       const textFileAsBlob = new Blob([config], { type: "text/plain" });
-      const fileNameToSaveAs = `kubeconfig-${user.username}.yaml`;
+      const fileNameToSaveAs = `kubeconfig-${user.metadata.name}.yaml`;
 
       const downloadLink = document.createElement("a");
       downloadLink.download = fileNameToSaveAs;


### PR DESCRIPTION
### What does this PR change?
Fix bug in kubeconfig file name.

### Does the PR depend on any other PRs or Issues? If yes, please list them.
None

### Checklist

I confirm, that I have...

- [X] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Added tests for this PR
- [X] Formatted the code using `npm run format` (if applicable)
- [X] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [X] Updated `CHANGELOG.md`
