### PR TITLE
Force reload login page on logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Ui cleanups in cluster lister, import and config screens from [niravparikh05](https://github.com/niravparikh05)
+- Fixed login failing right after logout from [meain](https://github.com/meain)
 
 ## [0.1.1] - 2022-08-09
 ### Changed

--- a/src/components/Header/ProjectSelector.js
+++ b/src/components/Header/ProjectSelector.js
@@ -53,7 +53,7 @@ const ProjectSelector = ({
     match.path === "/console/:projectId/:clusterName" &&
     match.params.projectId !== cachedProject
   ) {
-    return <Redirect to="/login" />;
+    window.location = "/#/login";
   }
 
   useEffect(() => {

--- a/src/components/UserInfo/index.js
+++ b/src/components/UserInfo/index.js
@@ -92,7 +92,7 @@ class UserInfo extends React.Component {
     }
 
     if (isChangeOrgSuccess) {
-      return <Redirect to="/login" />;
+      window.location = "/#/login";
     }
 
     return (

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -69,7 +69,7 @@ class App extends Component {
         !location.pathname.startsWith("/loginerror") &&
         !location.pathname.startsWith("/verify")
       )
-        return <Redirect to="/login" />;
+        window.location = "/#/login";
     } else if (location.pathname === "/ksettings") {
       return <Redirect to="/ksettings" />;
     } else if (location.pathname === "/") {


### PR DESCRIPTION
### What does this PR change?

Instead of a soft redirect, we do a browser navigation to login page forcing it to reload and fetch new kratos flow. We could probably try something to avoid having to do this reload later.

### Does the PR depend on any other PRs or Issues? If yes, please list them.

- fixes #122 

### Checklist

I confirm, that I have...

- [x] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Added tests for this PR
- [ ] Formatted the code using `npm run format` (if applicable)
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [ ] Updated `CHANGELOG.md`
