### PR TITLE
change to remove last access empty value from user list release updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+
+## [0.1.4]- 2022-10-14
 ### Changed
 - Hide copy button in user reset screen for non https webpages from [niravparikh05](https://github.com/niravparikh05)
 - Default to kubectl tab view in audit logs from [niravparikh05](https://github.com/niravparikh05)
@@ -37,7 +39,8 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/paralus/dashboard/compare/v0.1.3...HEAD
+[Unreleased]: https://github.com/paralus/dashboard/compare/v0.1.4...HEAD
+[0.1.4]: https://github.com/paralus/dashboard/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/paralus/dashboard/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/paralus/dashboard/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/paralus/dashboard/compare/v0.1.1...v0.1.0

--- a/src/appMain/routes/users/routes/UsersList/UserList.js
+++ b/src/appMain/routes/users/routes/UsersList/UserList.js
@@ -622,11 +622,6 @@ class UserList extends React.Component {
       {
         type: "regular",
         isExpandable: false,
-        value: lastAccessDetails,
-      },
-      {
-        type: "regular",
-        isExpandable: false,
         value: actionDetails,
       },
     ];


### PR DESCRIPTION
### What does this PR change?

- change to remove last access empty value from user list and update changelog for release 

### Does the PR depend on any other PRs or Issues? If yes, please list them.

- No

### Checklist

I confirm, that I have...

- [ ] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Added tests for this PR
- [ ] Formatted the code using `npm run format` (if applicable)
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [ ] Updated `CHANGELOG.md`
