### PR TITLE
Fix managed cluster access button for read only users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+- Fix access to cluster manage buttons shown for NAMESPACE-READ-ONLY user from [mabhi](https://github.com/mabhi)
+
 ## [0.1.5]- 2022-11-04
 ### Added
 - Show last access time in users list page from [akshay196](https://github.com/akshay196)

--- a/src/app/routes/edges/routes/PrivateEdgeList/index.js
+++ b/src/app/routes/edges/routes/PrivateEdgeList/index.js
@@ -1198,7 +1198,9 @@ class PrivateEdgeList extends React.Component {
     const { match, UserSession, Projects, sshEdges, partnerDetail } =
       this.props;
     let data = [];
-    const roles = [];
+    const roles = this.props.userAndRoleDetail.spec.permissions.map(
+      (p) => p.role
+    );
     if (!this.state.edges) {
       return null;
     }
@@ -1349,7 +1351,10 @@ class PrivateEdgeList extends React.Component {
                                   iconOnly={true}
                                 />
                               )}
-                              {this.state.userRole !== "READ_ONLY_OPS" && (
+                              {!(
+                                roles.includes("NAMESPACE_READ_ONLY") ||
+                                roles.includes("READ_ONLY_OPS")
+                              ) && (
                                 <Tooltip title="Kubectl Settings">
                                   <IconButton
                                     aria-label="edit"
@@ -1362,7 +1367,10 @@ class PrivateEdgeList extends React.Component {
                                   </IconButton>
                                 </Tooltip>
                               )}
-                              {this.state.userRole !== "READ_ONLY_OPS" && (
+                              {!(
+                                roles.includes("NAMESPACE_READ_ONLY") ||
+                                roles.includes("READ_ONLY_OPS")
+                              ) && (
                                 <DeleteIconComponent
                                   key={n.metadata.name}
                                   button={{

--- a/src/app/routes/edges/routes/PrivateEdgeList/index.js
+++ b/src/app/routes/edges/routes/PrivateEdgeList/index.js
@@ -1198,9 +1198,6 @@ class PrivateEdgeList extends React.Component {
     const { match, UserSession, Projects, sshEdges, partnerDetail } =
       this.props;
     let data = [];
-    const roles = this.props.userAndRoleDetail.spec.permissions.map(
-      (p) => p.role
-    );
     if (!this.state.edges) {
       return null;
     }
@@ -1250,6 +1247,16 @@ class PrivateEdgeList extends React.Component {
         }
       }
       return ready;
+    };
+
+    const hasWriteAccessInCluster = (projectName) => {
+      let hasWriteAccess = false;
+      var allPermissions = this.props.userAndRoleDetail.spec.permissions
+        .filter((obj) => obj.project === projectName)
+        .map((item) => item.permissions);
+      let deduplicatedPermissions = new Set(allPermissions.flat(1));
+      hasWriteAccess = deduplicatedPermissions.has("cluster.write");
+      return hasWriteAccess;
     };
 
     return (
@@ -1351,10 +1358,7 @@ class PrivateEdgeList extends React.Component {
                                   iconOnly={true}
                                 />
                               )}
-                              {!(
-                                roles.includes("NAMESPACE_READ_ONLY") ||
-                                roles.includes("READ_ONLY_OPS")
-                              ) && (
+                              {hasWriteAccessInCluster(n.metadata.project) && (
                                 <Tooltip title="Kubectl Settings">
                                   <IconButton
                                     aria-label="edit"
@@ -1367,10 +1371,7 @@ class PrivateEdgeList extends React.Component {
                                   </IconButton>
                                 </Tooltip>
                               )}
-                              {!(
-                                roles.includes("NAMESPACE_READ_ONLY") ||
-                                roles.includes("READ_ONLY_OPS")
-                              ) && (
+                              {hasWriteAccessInCluster(n.metadata.project) && (
                                 <DeleteIconComponent
                                   key={n.metadata.name}
                                   button={{


### PR DESCRIPTION
### What does this PR change?

- Fixes Cluster manage buttons access for read only user


### Does the PR depend on any other PRs or Issues? If yes, please list them.

- No

### Checklist

I confirm, that I have...

- [x] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Added tests for this PR
- [x] Formatted the code using `npm run format` (if applicable)
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [x] Updated `CHANGELOG.md`
