### PR TITLE
fix: show kratos errors information on error page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+### Fixed
+- Fix showing Kratos information on error page [akshay196](https://github.com/akshay196)
 
 ## [0.1.8]- 2023-02-24
 ### Fixed

--- a/src/containers/Auth/ErrorPage.js
+++ b/src/containers/Auth/ErrorPage.js
@@ -25,25 +25,32 @@ const ErrorPage = (props) => {
   const history = useHistory();
   const [errorInfo, setErrorInfo] = useState(null);
   const search = useLocation().search;
-  const errorCodeInput = new URLSearchParams(search).get("error");
+  const errorCodeInput = new URLSearchParams(search).get("id");
 
-  const moveToDashboard = (e) => {
+  const moveToDashboard = () => {
     history.push({
       pathname: "/",
     });
   };
 
-  const getKratosError = (errorCode) =>
+  const getKratosError = (errorCode) => {
     newKratosSdk()
       .getSelfServiceError(errorCode)
-      .then(({ resp }) => {
-        if (resp && resp.length) {
-          setErrorInfo(resp[0]);
+      .then(({ data: resp }) => {
+        if (resp) {
+          setErrorInfo(resp.error);
         }
       })
-      .catch((errorResp) => {
+      .catch((err) => {
         setErrorInfo(null);
+        switch (err.response?.status) {
+          case (404, 403, 410):
+            // The error id could not be found or fetched or
+            // expired. Let's just redirect home!
+            moveToDashboard();
+        }
       });
+  };
 
   useEffect((_) => {
     if (errorCodeInput && errorCodeInput !== "") {
@@ -57,39 +64,36 @@ const ErrorPage = (props) => {
         <PageLayout alignItems="left">
           <h1
             className="p-0"
-            style={{ marginBottom: "50px", color: "#ff9800", fontSize: "55px" }}
+            style={{ marginBottom: "10px", color: "#ff9800", fontSize: "55px" }}
           >
-            Oops
+            Oops!
           </h1>
           <p style={style.helpText} className="pt-0">
-            An error occured, please contact your administrator to get it fixed
-            ...!!!{" "}
+            An error occured, please contact your administrator to get it fixed.
           </p>
           {errorInfo && errorInfo !== null ? (
             <>
               <Paper variant="outlined" style={{ marginBottom: "50px" }}>
-                <span style={{ color: "dodgerblue", fontSize: "16px" }}>
-                  Code : {errorInfo.code}
-                </span>
-                <br></br>
-                <span style={{ color: "dodgerblue", fontSize: "16px" }}>
-                  Message : {errorInfo.message}
-                </span>
+                {errorInfo.code != null ? (
+                  <p style={{ color: "dodgerblue", fontSize: "16px" }}>
+                    Code : {errorInfo.code}
+                  </p>
+                ) : null}
+                {errorInfo.message != null ? (
+                  <p style={{ color: "dodgerblue", fontSize: "16px" }}>
+                    Message : {errorInfo.message}
+                  </p>
+                ) : null}
+                {errorInfo.reason != null ? (
+                  <p style={{ color: "dodgerblue", fontSize: "16px" }}>
+                    Reason : {errorInfo.reason}
+                  </p>
+                ) : null}
               </Paper>
             </>
           ) : null}
           <Button variant="contained" color="primary" onClick={moveToDashboard}>
             Go to Homepage
-          </Button>
-          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-          <Button
-            variant="contained"
-            color="primary"
-            target={"_blank"}
-            href="https://www.paralus.io/docs"
-          >
-            Paralus Docs
           </Button>
         </PageLayout>
       </MuiThemeProvider>


### PR DESCRIPTION
### What does this PR change?
Fetch and display error information from Kratos on Error page.

### Does the PR depend on any other PRs or Issues? If yes, please list them.

None

### Checklist

I confirm, that I have...

- [X] Read and followed the contributing guide in `CONTRIBUTING.md`
- [X] Added tests for this PR
- [X] Formatted the code using `npm run format` (if applicable)
- [X] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [X] Updated `CHANGELOG.md`
