### PR TITLE
chore: add dependabot.yml and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# See the GH CODEOWNERS docs: https://help.github.com/articles/about-codeowners
+
+# Default owners for everything in the repo.
+*       @niravparikh05 @akshay196

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      # Prefix all commit messages with "chore(deps): "
+      prefix: "chore(deps)"
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      # Prefix all commit messages with "chore(deps): "
+      prefix: "chore(deps)"
+    # Disable version updates (no impact on security updates)
+    open-pull-requests-limit: 0


### PR DESCRIPTION
### What does this PR change?

Enable GitHub dependabot bot by adding its config. Adding CODEOWERS file.

### Does the PR depend on any other PRs or Issues? If yes, please list them.

None

### Checklist

I confirm, that I have...

- [ ] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Added tests for this PR
- [ ] Formatted the code using `npm run format` (if applicable)
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [ ] Updated `CHANGELOG.md`
