### PR TITLE
Pinned IDP mapper url to v0.2.2 version

### DIFF
--- a/src/appMain/routes/sso/RegistrationWizard.js
+++ b/src/appMain/routes/sso/RegistrationWizard.js
@@ -792,7 +792,7 @@ const RegistrationWizard = (props) => {
                         ? idpResponse?.spec?.mapperUrl
                         : idpPayload?.spec?.providerName === "generic"
                         ? idpResponse?.spec?.mapperUrl
-                        : `https://raw.githubusercontent.com/paralus/paralus/main/_kratos/oidc-mappers/` +
+                        : `https://raw.githubusercontent.com/paralus/paralus/v0.2.2/_kratos/oidc-mappers/` +
                           idpPayload?.spec?.providerName +
                           ".jsonnet",
                     }}


### PR DESCRIPTION

### What does this PR change?

Using an IDP mapper url from main branch is prone to failures if it gets changed. Hence pinned the mapper URLs to a tag.


### Does the PR depend on any other PRs or Issues? If yes, please list them.

None

### Checklist

I confirm, that I have...

- [ ] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Added tests for this PR
- [ ] Formatted the code using `npm run format` (if applicable)
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [ ] Updated `CHANGELOG.md`
