### PR TITLE
build: update nginx to 1.25.2 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN yarn install --pure-lockfile --network-timeout 600000
 COPY . .
 RUN yarn run build
 
-FROM nginx:1.24.0
+FROM nginx:1.25.2
 EXPOSE 80
 COPY ./deploy/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/dist /usr/share/nginx/html


### PR DESCRIPTION
### What does this PR change?

Update nginx to 1.25.2 (latest) from 1.24.0 in Dockerfile. This should mitigate the vulnerability being reported by Trivy scanner.

CI failure #214 

### Does the PR depend on any other PRs or Issues? If yes, please list them.

None

### Checklist

I confirm, that I have...

- [ ] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Added tests for this PR
- [ ] Formatted the code using `npm run format` (if applicable)
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [ ] Updated `CHANGELOG.md`
