### PR TITLE
fix(user): make first/last name optional and hide empty name in profile

### DIFF
--- a/src/appMain/routes/users/routes/NewUser/components/Profile.js
+++ b/src/appMain/routes/users/routes/NewUser/components/Profile.js
@@ -79,7 +79,7 @@ const Profile = ({
               <>
                 <div className="col-md-6">
                   <TextValidator
-                    required
+                    // required
                     margin="dense"
                     id="first_name"
                     name="First Name"
@@ -87,13 +87,13 @@ const Profile = ({
                     label="First Name"
                     onChange={handleAccountChange("first_name")}
                     fullWidth
-                    validators={["required"]}
-                    errorMessages={["this field is required"]}
+                    // validators={["required"]}
+                    // errorMessages={["this field is required"]}
                   />
                 </div>
                 <div className="col-md-6">
                   <TextValidator
-                    required
+                    // required
                     margin="dense"
                     id="last_name"
                     name="Last Name"
@@ -101,8 +101,8 @@ const Profile = ({
                     label="Last Name"
                     onChange={handleAccountChange("last_name")}
                     fullWidth
-                    validators={["required"]}
-                    errorMessages={["this field is required"]}
+                    // validators={["required"]}
+                    // errorMessages={["this field is required"]}
                   />
                 </div>
 

--- a/src/appMain/routes/users/routes/UsersList/components/CreateUserDialog.js
+++ b/src/appMain/routes/users/routes/UsersList/components/CreateUserDialog.js
@@ -78,7 +78,7 @@ const CreateUserDialog = (props) => {
 
               <div className="col-md-6">
                 <TextValidator
-                  required
+                  // required
                   margin="dense"
                   id="first_name"
                   name="First Name"
@@ -86,13 +86,13 @@ const CreateUserDialog = (props) => {
                   label="First Name"
                   onChange={handleAccountChange("first_name")}
                   fullWidth
-                  validators={["required"]}
-                  errorMessages={["this field is required"]}
+                  // validators={["required"]}
+                  // errorMessages={["this field is required"]}
                 />
               </div>
               <div className="col-md-6">
                 <TextValidator
-                  required
+                  // required
                   margin="dense"
                   id="last_name"
                   name="Last Name"
@@ -100,8 +100,8 @@ const CreateUserDialog = (props) => {
                   label="Last Name"
                   onChange={handleAccountChange("last_name")}
                   fullWidth
-                  validators={["required"]}
-                  errorMessages={["this field is required"]}
+                  // validators={["required"]}
+                  // errorMessages={["this field is required"]}
                 />
               </div>
 

--- a/src/components/UserInfo/Profile.js
+++ b/src/components/UserInfo/Profile.js
@@ -63,6 +63,9 @@ class Profile extends React.Component {
     const { open } = this.state;
     if (!user) return null;
 
+    const fullName = [user.spec.firstName, user.spec.lastName]
+      .filter(Boolean)
+      .join(" ");
     return (
       <Dialog
         open={open}
@@ -75,12 +78,12 @@ class Profile extends React.Component {
         <DialogContent className="p-0">
           <hr className="m-0" />
           <div style={style.profileContainer}>
-            {!!`${user.spec.firstName}${user.spec.lastName}`.length && (
+            {fullName && (
               <>
                 <div>
                   <b>Name</b>
                 </div>
-                <div className="">{`${user.spec.firstName} ${user.spec.lastName}`}</div>
+                <div className="">{fullName}</div>
               </>
             )}
             <div>


### PR DESCRIPTION
### What does this PR change?

- This PR fixes UI inconsistencies related to optional user name fields.

### Changes

- Removed `required` validation and asterisk (*) from First Name and Last Name fields:
  - Create User Dialog
  - New User Page

- Fixed profile display issue:
  - Prevents rendering of `undefined undefined`
  - Hides Name section if both first and last name are not set

### Steps to Reproduce (Before Fix)

1. Create a user without first/last name
2. Open user profile
3. Observe `undefined undefined` displayed

### After Fix

- First Name and Last Name are correctly treated as optional
- No misleading asterisk (*)
- Profile does not display name if not set

### Testing

- Created user without name → no errors
- Profile view → no name displayed
- Created user with name → displays correctly
-

### Does the PR depend on any other PRs or Issues? If yes, please list them.

- issues 154

### Checklist

I confirm, that I have...

- [ .] Read and followed the contributing guide in `CONTRIBUTING.md`
- [. ] Added tests for this PR
- [. ] Formatted the code using `npm run format` (if applicable)
- [ .] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [. ] Updated `CHANGELOG.md`
